### PR TITLE
Fix environment loading in scoutui driver

### DIFF
--- a/bin/scoutui_driver.rb
+++ b/bin/scoutui_driver.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 require_relative '../lib/scoutui'
 
 require 'logger'


### PR DESCRIPTION
- Instruct bash to load ruby using bin/env so that environment variables
  are properly loaded.
- Without this, env variables for rbenv aren't properly set which causes
  issues with gem loading